### PR TITLE
Adds the pull request body under the title as a full description of changes 

### DIFF
--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -17,7 +17,7 @@ jobs:
         run: |
           UPDATE_TITLE=$(echo "${UPDATE_TITLE_ENV}" | sed -e 's/\\/\\\\/g' -e 's/$/\\&/g')
           UPDATE_BODY=$(echo "${UPDATE_BODY_ENV}" | sed -e 's/^/&  /g' -e 's/\\/\\\\/g' -e 's/$/\\&/g')
-          sed -i "/## \[Unreleased\]/a\\\n- ### ${UPDATE_TITLE}n${UPDATE_BODY}n\n---\n" CHANGELOG.md
+          sed -i "/## \[Unreleased\]/a\\\n- ### ${UPDATE_TITLE}n${UPDATE_BODY}n---" CHANGELOG.md
         env:
           UPDATE_TITLE_ENV: '${{ github.event.pull_request.title }}'
           UPDATE_BODY_ENV: '${{ github.event.pull_request.body }}'

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -15,8 +15,8 @@ jobs:
           fetch-depth: 0
       - name: 'Update CHANGELOG.md'
         run: |
-          UPDATE_TITLE=$(echo "${UPDATE_TITLE_ENV}" | sed 's/$/\\&/g')
-          UPDATE_BODY=$(echo "${UPDATE_BODY_ENV}" | sed -e 's/^/&  /g' -e 's/$/\\&/g')
+          UPDATE_TITLE=$(echo "${UPDATE_TITLE_ENV}" | sed -e 's/\\/\\\\/g' -e 's/$/\\&/g')
+          UPDATE_BODY=$(echo "${UPDATE_BODY_ENV}" | sed -e 's/^/&  /g' -e 's/\\/\\\\/g' -e 's/$/\\&/g')
           sed -i "/## \[Unreleased\]/a\\\n- ### ${UPDATE_TITLE}n${UPDATE_BODY}n\n---\n" CHANGELOG.md
         env:
           UPDATE_TITLE_ENV: '${{ github.event.pull_request.title }}'

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -13,9 +13,14 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: Update version.txt
+      - name: 'Update CHANGELOG.md'
         run: |
-          sed -i '/## \[Unreleased\]/a \\ \n${{ github.event.pull_request.title }}' CHANGELOG.md
+          UPDATE_TITLE=$(echo "${UPDATE_TITLE_ENV}" | sed 's/$/\\&/g')
+          UPDATE_BODY=$(echo "${UPDATE_BODY_ENV}" | sed -e 's/^/&  /g' -e 's/$/\\&/g')
+          sed -i "/## \[Unreleased\]/a\\\n- ### ${UPDATE_TITLE}n${UPDATE_BODY}n\n---\n" CHANGELOG.md
+        env:
+          UPDATE_TITLE_ENV: '${{ github.event.pull_request.title }}'
+          UPDATE_BODY_ENV: '${{ github.event.pull_request.body }}'
       - name: Amend the last commit
         run: |
           git config --global user.email "noreply@github.com"


### PR DESCRIPTION
The `update-changelog` workflow will now place the body (sometimes appearing as the first comment) of the pull request under the title for a more detailed description of the merged changes. In addition to a good title, everyone is encouraged to make a concise description or list of the changes in each pull request.

Resolves #1